### PR TITLE
Rename redirect_uri to redirectUri.

### DIFF
--- a/app/oauth.js
+++ b/app/oauth.js
@@ -30,9 +30,8 @@ define(function() {
           'interactive': interactive,
           // url:'https://graph.facebook.com/oauth/access_token?client_id=' + clientId +
           url: 'https://glukit.appspot.com/authorize?client_id=' + clientId +
-              '&reponse_type=code' +
               // '&access_type=online' +
-              '&redirect_uri=' + encodeURIComponent(redirectUri)
+              '&redirectUri=' + encodeURIComponent(redirectUri) + '&response_type=code'
         }
         chrome.identity.launchWebAuthFlow(options, function(redirectUri) {
           if (chrome.runtime.lastError) {


### PR DESCRIPTION
This gets us closer to our goal. The first problem was the `osin` uses `redirectUri` rather than `redirect_uri`. The second one is that the `response_type` parameter didn't register properly unless placed at the end. It's not supposed to matter and that's definitely a problem on the server side that I'm going to look into. Meanwhile, this code completes the 'authorize' request but I couldn't get Chrome to complete the flow by issuing the `token` POST request. 
